### PR TITLE
fix: escape `.` character in help command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,7 +1882,7 @@ dependencies = [
 
 [[package]]
 name = "wordbot"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "log",
  "pretty_env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wordbot"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://dev.azure.com/ferozar/WordBot/_apis/build/status%2Fz0r3f.wordbot?branchName=refs%2Ftags%2F0.4.1)](https://dev.azure.com/ferozar/WordBot/_build/latest?definitionId=26&branchName=refs%2Ftags%2F0.4.1)
+[![Build Status](https://dev.azure.com/ferozar/WordBot/_apis/build/status%2Fz0r3f.wordbot?branchName=refs%2Ftags%2F0.4.2)](https://dev.azure.com/ferozar/WordBot/_build/latest?definitionId=26&branchName=refs%2Ftags%2F0.4.2)
 
 # Rust Dictionary Bot
 
@@ -84,11 +84,11 @@ To install the appropriate dependencies in the container, I relied on `ldd`, so 
 docker build --tag z0r3f/wordbot-docker:latest .
 ```
 ```shell
-docker tag z0r3f/wordbot-docker:latest z0r3f/wordbot-docker:0.4.1
+docker tag z0r3f/wordbot-docker:latest z0r3f/wordbot-docker:0.4.2
 ```
 ```shell
 docker push z0r3f/wordbot-docker:latest
-docker push z0r3f/wordbot-docker:0.4.1
+docker push z0r3f/wordbot-docker:0.4.2
 ```
 
 ## Contributing

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ steps:
       URBAN_DICTIONARY_KEY: $(URBAN_DICTIONARY_KEY)
 
   - task: Docker@2
-    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], '0.4.1'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranchName'], '0.4.2'))
     inputs:
       containerRegistry: 'Docker hub wordbot'
       repository: 'z0r3f/wordbot-docker'

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,13 +47,13 @@ async fn main() {
 }
 
 #[derive(BotCommands, Clone, Debug)]
-#[command(rename_rule = "lowercase", description = "These commands are supported. Without command I will send you the definition of the text that you sent me")]
+#[command(rename_rule = "lowercase", description = "These commands are supported\\. Without command I will send you the definition of the text that you sent me")]
 enum Command {
-    #[command(description = "Display this text.")]
+    #[command(description = "Display this text\\.")]
     Help,
-    #[command(description = "Seek the text in the dictionary.")]
+    #[command(description = "Seek the text in the dictionary\\.")]
     Info(String),
-    #[command(description = "Seek the text in the urban dictionary.")]
+    #[command(description = "Seek the text in the urban dictionary\\.")]
     Urban(String),
 }
 


### PR DESCRIPTION
Close #17 