### PR TITLE
Fix parentheses escaping in definitions for consistency

### DIFF
--- a/src/telegram.rs
+++ b/src/telegram.rs
@@ -175,7 +175,7 @@ mod tests {
             *[noun]*\n- a thing characteristic of its kind or illustrating a general rule\n\
             \n\
             *Definitions for* _test_:\n\
-            *[verb]*\n- take measures to check the quality, performance, or reliability of (something), especially before putting it into widespread use or practice\n\
+            *[verb]*\n- take measures to check the quality, performance, or reliability of \\(something\\), especially before putting it into widespread use or practice\n\
             \n\
         ";
 


### PR DESCRIPTION
- Escaped parentheses in definitions to maintain consistency.  
- Ensures clarity and uniformity in the handling of special characters. 